### PR TITLE
don't scroll on container change

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -301,7 +301,6 @@ export class GalleryContainer extends React.Component {
     structure = structure || this.props.structure;
     id = id || this.props.id;
     createMediaUrl = createMediaUrl || this.props.createMediaUrl;
-    console.log(structure);
 
     if (typeof customComponents.customImageRenderer === 'function') {
       ImageRenderer.customImageRenderer = customComponents.customImageRenderer;

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -167,13 +167,6 @@ export class GalleryContainer extends React.Component {
 
     if (hasPropsChanged) {
       reCreateGallery();
-      if (
-        !!nextProps.activeIndex && nextProps.activeIndex > 0 && 
-        nextProps.activeIndex && this.props.activeIndex
-        ) {
-        this.scrollToItem(nextProps.activeIndex, false, true, 0);
-      }
-
       if (this.props.isInDisplay !== nextProps.isInDisplay) {
         this.handleNavigation(nextProps.isInDisplay);
       }

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -167,8 +167,10 @@ export class GalleryContainer extends React.Component {
 
     if (hasPropsChanged) {
       reCreateGallery();
-
-      if (!!nextProps.activeIndex && nextProps.activeIndex > 0) {
+      if (
+        !!nextProps.activeIndex && nextProps.activeIndex > 0 && 
+        nextProps.activeIndex && this.props.activeIndex
+        ) {
         this.scrollToItem(nextProps.activeIndex, false, true, 0);
       }
 
@@ -306,6 +308,7 @@ export class GalleryContainer extends React.Component {
     structure = structure || this.props.structure;
     id = id || this.props.id;
     createMediaUrl = createMediaUrl || this.props.createMediaUrl;
+    console.log(structure);
 
     if (typeof customComponents.customImageRenderer === 'function') {
       ImageRenderer.customImageRenderer = customComponents.customImageRenderer;


### PR DESCRIPTION
**What** -  removing unneeded call for `scrollToItem` in `UNSAFE_componentWillReceiveProps`.
**Why** - calling the `scrollToItem` at that point is useless since there is no change that requires scrolling to `activeIndex` we simply update the gallery structure if needed. in addition on container change, the `scrollToItem` is called before the gallery container in the state is updated and so the scrolling is not accurate.