### PR TITLE
fix gallery slider navigation arrows

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -89,8 +89,7 @@ class SlideshowView extends React.Component {
     }
     return (
       this.isAllItemsLoaded(props) &&
-      (this.scrollPositionAtTheAndOfTheGallery(props) >= Math.floor(this.getScrollElementWidth(props)) ||
-        this.isLastItemByState())
+      this.scrollPositionAtTheAndOfTheGallery(props) >= Math.floor(this.getScrollElementWidth(props))
     );
   }
 
@@ -112,16 +111,9 @@ class SlideshowView extends React.Component {
     return !this.props.options.behaviourParams_gallery_horizontal_loop && this.isScrollEnd();
   }
 
-  isLastItem(props = this.props) {
-    const activeIndex = props?.activeIndex ?? this.state.activeIndex;
+  isLastItem() {
+    const activeIndex = this.state.activeIndex;
     return !this.props.options.behaviourParams_gallery_horizontal_loop && activeIndex >= this.props.totalItemsCount - 1;
-  }
-
-  isLastItemByState() {
-    return (
-      !this.props.options.behaviourParams_gallery_horizontal_loop &&
-      this.state.activeIndex >= this.props.totalItemsCount - 1
-    );
   }
 
   //__________________________________Slide show loop functions_____________________________________________

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -89,7 +89,8 @@ class SlideshowView extends React.Component {
     }
     return (
       this.isAllItemsLoaded(props) &&
-      this.scrollPositionAtTheAndOfTheGallery(props) >= Math.floor(this.getScrollElementWidth(props))
+      (this.scrollPositionAtTheAndOfTheGallery(props) >= Math.floor(this.getScrollElementWidth(props)) ||
+        this.isLastItemByState())
     );
   }
 
@@ -114,6 +115,13 @@ class SlideshowView extends React.Component {
   isLastItem(props = this.props) {
     const activeIndex = props?.activeIndex ?? this.state.activeIndex;
     return !this.props.options.behaviourParams_gallery_horizontal_loop && activeIndex >= this.props.totalItemsCount - 1;
+  }
+
+  isLastItemByState() {
+    return (
+      !this.props.options.behaviourParams_gallery_horizontal_loop &&
+      this.state.activeIndex >= this.props.totalItemsCount - 1
+    );
   }
 
   //__________________________________Slide show loop functions_____________________________________________

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1118,7 +1118,7 @@ class SlideshowView extends React.Component {
     const isScrollStart = this.isScrollStart(props);
     const isFirstItem = this.isFirstItem();
     const isScrollEnd = this.isScrollEnd(props);
-    const isLastItem = this.isLastItem(props);
+    const isLastItem = this.isLastItem();
 
     const atStart = isScrollStart || isFirstItem;
     const atEnd = isScrollEnd || isLastItem;


### PR DESCRIPTION
fix slider position not being calculated correctly for cases when images take all of gallery width and there for not hiding forward arrow


Before:
https://github.com/user-attachments/assets/ae043431-b9e1-47fd-88cb-e47f2c2f240a

After:
https://github.com/user-attachments/assets/ceb2f90b-b362-48b7-9921-43317d271976


