### PR TITLE
PG-752 trigger onGalleryScroll on initialize scroll position

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -98,6 +98,8 @@ export class GalleryContainer extends React.Component {
       this.scrollToItem(this.props.activeIndex, false, true, 0);
       const currentItem = this.galleryStructure.items[this.props.activeIndex];
       this.onGalleryScroll(currentItem.offset);
+    } else {
+      this.onGalleryScroll({ top: window.scrollY });
     }
   }
 


### PR DESCRIPTION
Can be visible that if scroll happens prior to gallery initialization, only the next user interaction (scroll) will cause the gallery to recalculate and show all items)

Not all images load:

https://github.com/user-attachments/assets/7273d698-a375-4f42-870c-b6aa43d8eef5


After fix:

https://github.com/user-attachments/assets/7e24caa7-39e1-482f-a2dc-1e0ef64ee6e4

