### PR TITLE
fix: hide thumbnails during prerender mode to prevent gallery flicker

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -666,12 +666,20 @@ export class GalleryContainer extends React.Component {
   createDynamicStyles({ overlayBackground }, isPrerenderMode) {
     const useSSROpacity =
       isPrerenderMode && !this.props.settings.disableSSROpacity;
+
+    let prerenderSelectors = `#pro-gallery-${this.props.id} .gallery-item-container`;
+
+    // Add thumbnails selector if thumbnails are enabled
+    if (
+      this.props.options?.hasThumbnails &&
+      this.props.options?.scrollDirection ===
+        GALLERY_CONSTS.scrollDirection.HORIZONTAL
+    ) {
+      prerenderSelectors += `, #pro-gallery-${this.props.id} .thumbnails-gallery`;
+    }
+
     this.dynamicStyles = `
-      ${
-        !useSSROpacity
-          ? ''
-          : `#pro-gallery-${this.props.id} .gallery-item-container { opacity: 0 }`
-      }
+      ${!useSSROpacity ? '' : `${prerenderSelectors} { opacity: 0 }`}
       ${
         !overlayBackground
           ? ''


### PR DESCRIPTION
- Conditionally includes thumbnails in the prerender opacity rule
- Only applies when hasThumbnails is true & gallery is horizontal