### PR TITLE
Revert disable visible items experiment

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -335,17 +335,12 @@ export class GalleryContainer extends React.Component {
     );
   }
 
-  getVisibleItems(
-    items,
-    container,
-    isPrerenderMode,
-    disableVisibleItemsOnPrerenderMode = false
-  ) {
+  getVisibleItems(items, container, isPrerenderMode) {
     const { gotFirstScrollEvent } = this.state;
     const scrollY = this.state?.scrollPosition?.top || 0;
     const { galleryHeight, scrollBase, galleryWidth } = container;
     if (
-      (isPrerenderMode && !disableVisibleItemsOnPrerenderMode) || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
+      isPrerenderMode || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
       isSEOMode() ||
       isEditMode() ||
       gotFirstScrollEvent ||

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -189,8 +189,7 @@ class GalleryView extends React.Component {
     const items = getVisibleItems(
       galleryStructure.galleryItems,
       container,
-      this.props.isPrerenderMode,
-      this.props.experimentalFeatures?.disableVisibleItemsOnPrerenderMode
+      this.props.isPrerenderMode
     );
     const itemsWithVirtualizationData =
       getItemsInViewportOrMarginByScrollLocation({

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -116,8 +116,7 @@ class SlideshowView extends React.Component {
     const visibleItemsCount = getVisibleItems(
       galleryStructure.galleryItems,
       container,
-      isPrerenderMode,
-      props.experimentalFeatures?.disableVisibleItemsOnPrerenderMode
+      isPrerenderMode
     ).length;
     return visibleItemsCount >= totalItemsCount;
   }
@@ -646,12 +645,7 @@ class SlideshowView extends React.Component {
       isPrerenderMode,
     } = props;
     const { activeIndex } = state;
-    const groups = getVisibleItems(
-      galleryGroups,
-      container,
-      isPrerenderMode,
-      props.experimentalFeatures?.disableVisibleItemsOnPrerenderMode
-    );
+    const groups = getVisibleItems(galleryGroups, container, isPrerenderMode);
     const galleryWidth =
       this.props.galleryContainerRef?.clientWidth ||
       container.galleryWidth ||

--- a/packages/lib/src/common/interfaces/galleryTypes.ts
+++ b/packages/lib/src/common/interfaces/galleryTypes.ts
@@ -33,9 +33,7 @@ export interface GalleryProps {
   enableExperimentalFeatures?: boolean;
   virtualizationSettings?: VirtualizationSettings;
   shouldDisableItemFocus?: boolean;
-  experimentalFeatures?: {
-    disableVisibleItemsOnPrerenderMode?: boolean;
-  };
+  experimentalFeatures?: {};
 }
 
 export interface GalleryState {


### PR DESCRIPTION
Since we merged this experiment and haven’t seen any measurable success, we should remove it for now.