### PR TITLE
Fix blueprint caching bug: Add scrollBase to container change detection (PG-960)

### DIFF
--- a/packages/blueprints/src/Blueprints.js
+++ b/packages/blueprints/src/Blueprints.js
@@ -245,6 +245,7 @@ class Blueprints {
           : !!newContainerParams.height && newContainerParams.height !== oldContainerParams.height,
         width:
           !oldContainerParams || (!!newContainerParams.width && newContainerParams.width !== oldContainerParams.width),
+        scrollBase: newContainerParams?.scrollBase !== oldContainerParams?.scrollBase,
       };
       return Object.keys(containerHasChanged).reduce((is, key) => {
         if (containerHasChanged[key]) {


### PR DESCRIPTION
## 🐛 Bug Fix: Blueprint Caching Issue (PG-960)

### **Problem**
Below-fold galleries were incorrectly autoplaying on initial render due to a blueprint caching bug. The `containerHasChanged` function in `Blueprints.js` was not detecting `scrollBase` changes, causing the blueprint system to return cached blueprints with stale `scrollBase: 0` values.

### **Root Cause**
The `containerHasChanged` function only checked for `height` and `width` changes but ignored `scrollBase` changes:

```javascript
// BEFORE - scrollBase changes were ignored
const containerHasChanged = {
  height: ...,
  width: ..., 
  // ❌ Missing scrollBase detection!
};
```

### **Solution**
Added `scrollBase` to the container change detection:

```javascript
// AFTER - scrollBase changes now detected
const containerHasChanged = {
  height: ...,
  width: ...,
  scrollBase: newContainerParams?.scrollBase !== oldContainerParams?.scrollBase, ✅
};
```

### **Impact**
- ✅ **Fixes** below-fold gallery autoplay issue

### **Testing**
- [x] Below-fold galleries no longer autoplay incorrectly
- [x] Above-fold galleries continue to work as expected

---

**Jira**: [PG-960](https://wix.atlassian.net/browse/PG-960)