### PR TITLE
Feature: Add thumbnail ratio property

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -332,6 +332,7 @@ export class GalleryContainer extends React.Component {
     this.galleryStructure = ItemsHelper.convertToGalleryItems(structure, {
       // TODO use same objects in the memory when the galleryItems are changed
       thumbnailSize: options[optionsMap.layoutParams.thumbnails.size],
+      thumbnailRatio: options[optionsMap.layoutParams.thumbnails.ratio] || 1,
       sharpParams: options.sharpParams,
       createMediaUrl,
     });

--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -71,9 +71,12 @@ class NavigationPanel extends React.Component {
         >
           {items.map(({ thumbnailItem, location, idx }) => {
             const highlighted = idx === activeIndex % clearedGalleryItems.length;
+            const thumbnailSize = options[optionsMap.layoutParams.thumbnails.size];
+            const thumbnailRatio = options[optionsMap.layoutParams.thumbnails.ratio] || 1;
+            const thumbnailHeight = thumbnailSize / thumbnailRatio;
             const itemStyle = {
-              width: options[optionsMap.layoutParams.thumbnails.size],
-              height: options[optionsMap.layoutParams.thumbnails.size],
+              width: thumbnailSize,
+              height: thumbnailHeight,
               overflow: 'hidden',
               backgroundImage: `url(${thumbnailItem.createUrl(
                 GALLERY_CONSTS.urlSizes.THUMBNAIL,

--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -23,18 +23,25 @@ class NavigationPanel extends React.Component {
     );
     const activeIndex = utils.inRange(this.props.activeIndex, clearedGalleryItems.length);
 
-    const { horizontalThumbnails, items, thumbnailsMargins, thumbnailsStyle, activeIndexOffsetMemory } =
-      thumbnailsLogic.getThumbnailsData({
-        items: this.props.items,
-        activeIndex,
-        options,
-        galleryStructure,
-        thumbnailAlignment,
-        containerHeight: this.props.container.height,
-        containerWidth: this.props.container.width,
-        activeIndexOffsetMemory: this.activeIndexOffsetMemory,
-        prevActiveIndex: this.prevActiveIndex,
-      });
+    const {
+      horizontalThumbnails,
+      items,
+      thumbnailsMargins,
+      thumbnailsStyle,
+      activeIndexOffsetMemory,
+      thumbnailWidth,
+      thumbnailHeight,
+    } = thumbnailsLogic.getThumbnailsData({
+      items: this.props.items,
+      activeIndex,
+      options,
+      galleryStructure,
+      thumbnailAlignment,
+      containerHeight: this.props.container.height,
+      containerWidth: this.props.container.width,
+      activeIndexOffsetMemory: this.activeIndexOffsetMemory,
+      prevActiveIndex: this.prevActiveIndex,
+    });
 
     this.prevActiveIndex = activeIndex;
     this.activeIndexOffsetMemory = activeIndexOffsetMemory;
@@ -71,11 +78,8 @@ class NavigationPanel extends React.Component {
         >
           {items.map(({ thumbnailItem, location, idx }) => {
             const highlighted = idx === activeIndex % clearedGalleryItems.length;
-            const thumbnailSize = options[optionsMap.layoutParams.thumbnails.size];
-            const thumbnailRatio = options[optionsMap.layoutParams.thumbnails.ratio] || 1;
-            const thumbnailHeight = thumbnailSize / thumbnailRatio;
             const itemStyle = {
-              width: thumbnailSize,
+              width: thumbnailWidth,
               height: thumbnailHeight,
               overflow: 'hidden',
               backgroundImage: `url(${thumbnailItem.createUrl(

--- a/packages/gallery/tests/styleParams/layoutParams_thumbnails_ratio.spec.js
+++ b/packages/gallery/tests/styleParams/layoutParams_thumbnails_ratio.spec.js
@@ -40,8 +40,8 @@ describe('options - layoutParams_thumbnails_ratio', () => {
     await driver.update();
     const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
     const { width, height } = thumbnailItem.props().style;
-    expect(width).to.eq(120);
-    expect(height).to.eq(160); // 120 / 0.75 = 160
+    expect(width).to.eq(90); // 120 * 0.75 = 90
+    expect(height).to.eq(120);
     driver.detach.proGallery();
   });
   it('should apply ratio of 1.333 (4:3 landscape thumbnails)', async () => {
@@ -55,11 +55,11 @@ describe('options - layoutParams_thumbnails_ratio', () => {
     await driver.update();
     const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
     const { width, height } = thumbnailItem.props().style;
-    expect(width).to.eq(120);
-    expect(height).to.be.closeTo(90, 1); // 120 / 1.333 ≈ 90
+    expect(width).to.be.closeTo(160, 1); // 120 * 1.333 ≈ 160
+    expect(height).to.eq(120);
     driver.detach.proGallery();
   });
-  it('should update thumbnail height when ratio changes', async () => {
+  it('should update thumbnail width when ratio changes', async () => {
     initialProps.options = Object.assign(initialProps.options, {
       [optionsMap.layoutParams.structure.galleryLayout]:
         GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
@@ -70,11 +70,11 @@ describe('options - layoutParams_thumbnails_ratio', () => {
     await driver.update();
     const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
     const { width, height } = thumbnailItem.props().style;
-    expect(width).to.eq(200);
-    expect(height).to.eq(100); // 200 / 2 = 100
+    expect(width).to.eq(400); // 200 * 2 = 400
+    expect(height).to.eq(200);
     driver.detach.proGallery();
   });
-  it('should apply ratio to width for vertical thumbnails (LEFT placement)', async () => {
+  it('should apply ratio to height for vertical thumbnails (LEFT placement)', async () => {
     initialProps.options = Object.assign(initialProps.options, {
       [optionsMap.layoutParams.structure.galleryLayout]:
         GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
@@ -86,12 +86,12 @@ describe('options - layoutParams_thumbnails_ratio', () => {
     await driver.update();
     const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
     const { width, height } = thumbnailItem.props().style;
-    // For vertical thumbnails: maintain height, adjust width
-    expect(height).to.eq(120); // height stays constant
-    expect(width).to.be.closeTo(160, 1); // 120 * 1.333 ≈ 160
+    // For vertical thumbnails: maintain width, adjust height
+    expect(width).to.eq(120); // width stays constant
+    expect(height).to.be.closeTo(90, 1); // 120 / 1.333 ≈ 90
     driver.detach.proGallery();
   });
-  it('should apply ratio to width for vertical thumbnails (RIGHT placement)', async () => {
+  it('should apply ratio to height for vertical thumbnails (RIGHT placement)', async () => {
     initialProps.options = Object.assign(initialProps.options, {
       [optionsMap.layoutParams.structure.galleryLayout]:
         GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
@@ -104,12 +104,12 @@ describe('options - layoutParams_thumbnails_ratio', () => {
     await driver.update();
     const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
     const { width, height } = thumbnailItem.props().style;
-    // For vertical thumbnails: maintain height, adjust width
-    expect(height).to.eq(120); // height stays constant
-    expect(width).to.be.closeTo(90, 1); // 120 * 0.75 = 90
+    // For vertical thumbnails: maintain width, adjust height
+    expect(width).to.eq(120); // width stays constant
+    expect(height).to.be.closeTo(160, 1); // 120 / 0.75 = 160
     driver.detach.proGallery();
   });
-  it('should apply ratio to height for horizontal thumbnails (TOP placement)', async () => {
+  it('should apply ratio to width for horizontal thumbnails (TOP placement)', async () => {
     initialProps.options = Object.assign(initialProps.options, {
       [optionsMap.layoutParams.structure.galleryLayout]:
         GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
@@ -121,9 +121,9 @@ describe('options - layoutParams_thumbnails_ratio', () => {
     await driver.update();
     const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
     const { width, height } = thumbnailItem.props().style;
-    // For horizontal thumbnails: maintain width, adjust height
-    expect(width).to.eq(120); // width stays constant
-    expect(height).to.be.closeTo(90, 1); // 120 / 1.333 ≈ 90
+    // For horizontal thumbnails: maintain height, adjust width
+    expect(height).to.eq(120); // height stays constant
+    expect(width).to.be.closeTo(160, 1); // 120 * 1.333 ≈ 160
     driver.detach.proGallery();
   });
   it('should apply ratio of 0.5625 (9:16 portrait thumbnails)', async () => {
@@ -137,8 +137,8 @@ describe('options - layoutParams_thumbnails_ratio', () => {
     await driver.update();
     const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
     const { width, height } = thumbnailItem.props().style;
-    expect(width).to.eq(120);
-    expect(height).to.be.closeTo(213.33, 1); // 120 / (9/16) = 120 / 0.5625 ≈ 213.33
+    expect(width).to.be.closeTo(67.5, 1); // 120 * (9/16) = 120 * 0.5625 = 67.5
+    expect(height).to.eq(120);
     driver.detach.proGallery();
   });
 });

--- a/packages/gallery/tests/styleParams/layoutParams_thumbnails_ratio.spec.js
+++ b/packages/gallery/tests/styleParams/layoutParams_thumbnails_ratio.spec.js
@@ -74,4 +74,71 @@ describe('options - layoutParams_thumbnails_ratio', () => {
     expect(height).to.eq(100); // 200 / 2 = 100
     driver.detach.proGallery();
   });
+  it('should apply ratio to width for vertical thumbnails (LEFT placement)', async () => {
+    initialProps.options = Object.assign(initialProps.options, {
+      [optionsMap.layoutParams.structure.galleryLayout]:
+        GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
+      [optionsMap.layoutParams.thumbnails.size]: 120,
+      [optionsMap.layoutParams.thumbnails.ratio]: 1.333,
+      [optionsMap.layoutParams.thumbnails.alignment]: GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT,
+    });
+    driver.mount.proGallery(initialProps);
+    await driver.update();
+    const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
+    const { width, height } = thumbnailItem.props().style;
+    // For vertical thumbnails: maintain height, adjust width
+    expect(height).to.eq(120); // height stays constant
+    expect(width).to.be.closeTo(160, 1); // 120 * 1.333 ≈ 160
+    driver.detach.proGallery();
+  });
+  it('should apply ratio to width for vertical thumbnails (RIGHT placement)', async () => {
+    initialProps.options = Object.assign(initialProps.options, {
+      [optionsMap.layoutParams.structure.galleryLayout]:
+        GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
+      [optionsMap.layoutParams.thumbnails.size]: 120,
+      [optionsMap.layoutParams.thumbnails.ratio]: 0.75,
+      [optionsMap.layoutParams.thumbnails.alignment]:
+        GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT,
+    });
+    driver.mount.proGallery(initialProps);
+    await driver.update();
+    const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
+    const { width, height } = thumbnailItem.props().style;
+    // For vertical thumbnails: maintain height, adjust width
+    expect(height).to.eq(120); // height stays constant
+    expect(width).to.be.closeTo(90, 1); // 120 * 0.75 = 90
+    driver.detach.proGallery();
+  });
+  it('should apply ratio to height for horizontal thumbnails (TOP placement)', async () => {
+    initialProps.options = Object.assign(initialProps.options, {
+      [optionsMap.layoutParams.structure.galleryLayout]:
+        GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
+      [optionsMap.layoutParams.thumbnails.size]: 120,
+      [optionsMap.layoutParams.thumbnails.ratio]: 1.333,
+      [optionsMap.layoutParams.thumbnails.alignment]: GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP,
+    });
+    driver.mount.proGallery(initialProps);
+    await driver.update();
+    const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
+    const { width, height } = thumbnailItem.props().style;
+    // For horizontal thumbnails: maintain width, adjust height
+    expect(width).to.eq(120); // width stays constant
+    expect(height).to.be.closeTo(90, 1); // 120 / 1.333 ≈ 90
+    driver.detach.proGallery();
+  });
+  it('should apply ratio of 0.5625 (9:16 portrait thumbnails)', async () => {
+    initialProps.options = Object.assign(initialProps.options, {
+      [optionsMap.layoutParams.structure.galleryLayout]:
+        GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
+      [optionsMap.layoutParams.thumbnails.size]: 120,
+      [optionsMap.layoutParams.thumbnails.ratio]: 9 / 16,
+    });
+    driver.mount.proGallery(initialProps);
+    await driver.update();
+    const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
+    const { width, height } = thumbnailItem.props().style;
+    expect(width).to.eq(120);
+    expect(height).to.be.closeTo(213.33, 1); // 120 / (9/16) = 120 / 0.5625 ≈ 213.33
+    driver.detach.proGallery();
+  });
 });

--- a/packages/gallery/tests/styleParams/layoutParams_thumbnails_ratio.spec.js
+++ b/packages/gallery/tests/styleParams/layoutParams_thumbnails_ratio.spec.js
@@ -1,0 +1,77 @@
+import GalleryDriver from '../drivers/reactDriver';
+import { expect } from 'chai';
+import { GALLERY_CONSTS, optionsMap } from 'pro-gallery-lib';
+import { images2 } from '../drivers/mocks/items';
+import { options, container } from '../drivers/mocks/styles';
+
+describe('options - layoutParams_thumbnails_ratio', () => {
+  let driver;
+  let initialProps;
+  beforeEach(() => {
+    driver = new GalleryDriver();
+    initialProps = {
+      container,
+      items: images2,
+      options,
+    };
+  });
+  it('should use default ratio of 1 (square thumbnails)', async () => {
+    initialProps.options = Object.assign(initialProps.options, {
+      [optionsMap.layoutParams.structure.galleryLayout]:
+        GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
+      [optionsMap.layoutParams.thumbnails.size]: 120,
+    });
+    driver.mount.proGallery(initialProps);
+    await driver.update();
+    const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
+    const { width, height } = thumbnailItem.props().style;
+    expect(width).to.eq(120);
+    expect(height).to.eq(120);
+    driver.detach.proGallery();
+  });
+  it('should apply ratio of 0.75 (3:4 portrait thumbnails)', async () => {
+    initialProps.options = Object.assign(initialProps.options, {
+      [optionsMap.layoutParams.structure.galleryLayout]:
+        GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
+      [optionsMap.layoutParams.thumbnails.size]: 120,
+      [optionsMap.layoutParams.thumbnails.ratio]: 0.75,
+    });
+    driver.mount.proGallery(initialProps);
+    await driver.update();
+    const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
+    const { width, height } = thumbnailItem.props().style;
+    expect(width).to.eq(120);
+    expect(height).to.eq(160); // 120 / 0.75 = 160
+    driver.detach.proGallery();
+  });
+  it('should apply ratio of 1.333 (4:3 landscape thumbnails)', async () => {
+    initialProps.options = Object.assign(initialProps.options, {
+      [optionsMap.layoutParams.structure.galleryLayout]:
+        GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
+      [optionsMap.layoutParams.thumbnails.size]: 120,
+      [optionsMap.layoutParams.thumbnails.ratio]: 1.333,
+    });
+    driver.mount.proGallery(initialProps);
+    await driver.update();
+    const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
+    const { width, height } = thumbnailItem.props().style;
+    expect(width).to.eq(120);
+    expect(height).to.be.closeTo(90, 1); // 120 / 1.333 ≈ 90
+    driver.detach.proGallery();
+  });
+  it('should update thumbnail height when ratio changes', async () => {
+    initialProps.options = Object.assign(initialProps.options, {
+      [optionsMap.layoutParams.structure.galleryLayout]:
+        GALLERY_CONSTS[optionsMap.layoutParams.structure.galleryLayout].THUMBNAIL,
+      [optionsMap.layoutParams.thumbnails.size]: 200,
+      [optionsMap.layoutParams.thumbnails.ratio]: 2,
+    });
+    driver.mount.proGallery(initialProps);
+    await driver.update();
+    const thumbnailItem = driver.find.selector('.thumbnailItem').at(0);
+    const { width, height } = thumbnailItem.props().style;
+    expect(width).to.eq(200);
+    expect(height).to.eq(100); // 200 / 2 = 100
+    driver.detach.proGallery();
+  });
+});

--- a/packages/layouts/src/classes/galleryItem.js
+++ b/packages/layouts/src/classes/galleryItem.js
@@ -74,6 +74,7 @@ class GalleryItem {
       this.sharpParams.usm = {};
     }
     this.thumbnailSize = config.thumbnailSize || 120;
+    this.thumbnailRatio = config.thumbnailRatio || 1;
 
     this.resetUrls();
     this.updateSharpParams();
@@ -389,10 +390,11 @@ class GalleryItem {
 
   get thumbnail_url() {
     if (!this.urls.thumbnail_url) {
+      const thumbnailHeight = this.thumbnailSize / this.thumbnailRatio;
       this.urls.thumbnail_url = this.processedMediaUrl(
         GALLERY_CONSTS.resizeMethods.FILL,
         this.thumbnailSize,
-        this.thumbnailSize,
+        thumbnailHeight,
         { quality: 70 }
       );
     }

--- a/packages/lib/src/common/defaultOptions.ts
+++ b/packages/lib/src/common/defaultOptions.ts
@@ -54,6 +54,7 @@ const defaultOptions = flattenObject({
       enable: false,
       position: GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.position].OUTSIDE_GALLERY,
       alignment: GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM,
+      ratio: 1,
     },
     navigationArrows: {
       enable: true,

--- a/packages/lib/src/common/interfaces/layoutParams.ts
+++ b/packages/lib/src/common/interfaces/layoutParams.ts
@@ -25,6 +25,7 @@ export interface Thumbnails {
   marginToGallery?: number;
   size?: number;
   alignment?: 'BOTTOM' | 'RIGHT' | 'LEFT' | 'TOP';
+  ratio?: number;
 }
 
 export interface Scatter {

--- a/packages/lib/src/common/v4DefaultOptions.ts
+++ b/packages/lib/src/common/v4DefaultOptions.ts
@@ -52,6 +52,7 @@ const defaultV4Options = {
       enable: false,
       position: GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.position].OUTSIDE_GALLERY,
       alignment: GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM,
+      ratio: 1,
     },
     navigationArrows: {
       enable: true,

--- a/packages/lib/src/core/helpers/dimensionsHelper.js
+++ b/packages/lib/src/core/helpers/dimensionsHelper.js
@@ -115,15 +115,10 @@ class DimensionsHelper {
   }
 
   getThumbnailHeightDelta() {
-    const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
-        return (
-          thumbnailSize +
-          this.options[optionsMap.layoutParams.structure.gallerySpacing] +
-          this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
-        );
+        return this.getThumbnailSize();
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
         return 0;
@@ -132,18 +127,13 @@ class DimensionsHelper {
     }
   }
   getThumbnailWidthDelta() {
-    const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
         return 0;
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
-        return (
-          thumbnailSize +
-          this.options[optionsMap.layoutParams.structure.gallerySpacing] +
-          this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
-        );
+        return this.getThumbnailSize();
       default:
         break;
     }

--- a/packages/lib/src/core/helpers/dimensionsHelper.js
+++ b/packages/lib/src/core/helpers/dimensionsHelper.js
@@ -106,16 +106,19 @@ class DimensionsHelper {
     });
   }
 
+  _getThumbnailDeltaSize() {
+    return (
+      this.options[optionsMap.layoutParams.thumbnails.size] +
+      this.options[optionsMap.layoutParams.structure.gallerySpacing] +
+      this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
+    );
+  }
+
   getThumbnailHeightDelta() {
-    const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
-        return (
-          thumbnailSize +
-          this.options[optionsMap.layoutParams.structure.gallerySpacing] +
-          this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
-        );
+        return this._getThumbnailDeltaSize();
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
         return 0;
@@ -123,19 +126,15 @@ class DimensionsHelper {
         break;
     }
   }
+
   getThumbnailWidthDelta() {
-    const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
         return 0;
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
-        return (
-          thumbnailSize +
-          this.options[optionsMap.layoutParams.structure.gallerySpacing] +
-          this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
-        );
+        return this._getThumbnailDeltaSize();
       default:
         break;
     }

--- a/packages/lib/src/core/helpers/dimensionsHelper.js
+++ b/packages/lib/src/core/helpers/dimensionsHelper.js
@@ -106,19 +106,16 @@ class DimensionsHelper {
     });
   }
 
-  getThumbnailSize() {
-    const fixedThumbnailSize =
-      this.options[optionsMap.layoutParams.thumbnails.size] +
-      this.options[optionsMap.layoutParams.structure.gallerySpacing] +
-      this.options[optionsMap.layoutParams.thumbnails.marginToGallery];
-    return fixedThumbnailSize;
-  }
-
   getThumbnailHeightDelta() {
+    const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
-        return this.getThumbnailSize();
+        return (
+          thumbnailSize +
+          this.options[optionsMap.layoutParams.structure.gallerySpacing] +
+          this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
+        );
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
         return 0;
@@ -127,13 +124,18 @@ class DimensionsHelper {
     }
   }
   getThumbnailWidthDelta() {
+    const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
         return 0;
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
-        return this.getThumbnailSize();
+        return (
+          thumbnailSize +
+          this.options[optionsMap.layoutParams.structure.gallerySpacing] +
+          this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
+        );
       default:
         break;
     }

--- a/packages/lib/src/core/helpers/dimensionsHelper.js
+++ b/packages/lib/src/core/helpers/dimensionsHelper.js
@@ -115,10 +115,18 @@ class DimensionsHelper {
   }
 
   getThumbnailHeightDelta() {
+    const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
+    const thumbnailRatio = this.options[optionsMap.layoutParams.thumbnails.ratio] || 1;
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
-        return this.getThumbnailSize();
+        // For horizontal thumbnails: maintain width, adjust height
+        // Height = thumbnailSize / thumbnailRatio
+        return (
+          thumbnailSize / thumbnailRatio +
+          this.options[optionsMap.layoutParams.structure.gallerySpacing] +
+          this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
+        );
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
         return 0;
@@ -127,13 +135,21 @@ class DimensionsHelper {
     }
   }
   getThumbnailWidthDelta() {
+    const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
+    const thumbnailRatio = this.options[optionsMap.layoutParams.thumbnails.ratio] || 1;
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
         return 0;
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
-        return this.getThumbnailSize();
+        // For vertical thumbnails: maintain height, adjust width
+        // Width = thumbnailSize * thumbnailRatio
+        return (
+          thumbnailSize * thumbnailRatio +
+          this.options[optionsMap.layoutParams.structure.gallerySpacing] +
+          this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
+        );
       default:
         break;
     }

--- a/packages/lib/src/core/helpers/dimensionsHelper.js
+++ b/packages/lib/src/core/helpers/dimensionsHelper.js
@@ -116,14 +116,11 @@ class DimensionsHelper {
 
   getThumbnailHeightDelta() {
     const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
-    const thumbnailRatio = this.options[optionsMap.layoutParams.thumbnails.ratio] || 1;
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
-        // For horizontal thumbnails: maintain width, adjust height
-        // Height = thumbnailSize / thumbnailRatio
         return (
-          thumbnailSize / thumbnailRatio +
+          thumbnailSize +
           this.options[optionsMap.layoutParams.structure.gallerySpacing] +
           this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
         );
@@ -136,17 +133,14 @@ class DimensionsHelper {
   }
   getThumbnailWidthDelta() {
     const thumbnailSize = this.options[optionsMap.layoutParams.thumbnails.size];
-    const thumbnailRatio = this.options[optionsMap.layoutParams.thumbnails.ratio] || 1;
     switch (this.options[optionsMap.layoutParams.thumbnails.alignment]) {
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM:
         return 0;
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].RIGHT:
       case GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].LEFT:
-        // For vertical thumbnails: maintain height, adjust width
-        // Width = thumbnailSize * thumbnailRatio
         return (
-          thumbnailSize * thumbnailRatio +
+          thumbnailSize +
           this.options[optionsMap.layoutParams.structure.gallerySpacing] +
           this.options[optionsMap.layoutParams.thumbnails.marginToGallery]
         );

--- a/packages/lib/src/core/helpers/optionsBackwardConverter.ts
+++ b/packages/lib/src/core/helpers/optionsBackwardConverter.ts
@@ -34,7 +34,6 @@ function reverseMigrateOptions(flatOptionsObject) {
     [...reversedLayoutParams].map((ele) => [...ele].reverse())
   );
   oldOptions = process_new_to_old_ThumbnailAlignment(oldOptions);
-  oldOptions = process_new_to_old_ThumbnailRatio(oldOptions);
   oldOptions = process_new_to_old_ScrollDirection(oldOptions);
   oldOptions = process_new_to_old_LayoutOrientation(oldOptions);
   oldOptions = process_new_to_old_groupsOrder(oldOptions);
@@ -85,12 +84,6 @@ function process_new_to_old_ThumbnailAlignment(obj) {
   let _obj = obj;
   _obj = namingChange(_obj, optionsMap.layoutParams.thumbnails.alignment, 'galleryThumbnailsAlignment');
   _obj['galleryThumbnailsAlignment'] = _obj['galleryThumbnailsAlignment']?.toLowerCase();
-  return _obj;
-}
-function process_new_to_old_ThumbnailRatio(obj) {
-  // Remove the ratio property as it doesn't exist in v3
-  let _obj = obj;
-  delete _obj[optionsMap.layoutParams.thumbnails.ratio];
   return _obj;
 }
 function process_new_to_old_targetItemSizeUnit(obj) {

--- a/packages/lib/src/core/helpers/optionsBackwardConverter.ts
+++ b/packages/lib/src/core/helpers/optionsBackwardConverter.ts
@@ -24,6 +24,7 @@ function addOldOptions(flatOptions) {
 
 function reverseMigrateOptions(flatOptionsObject) {
   let oldOptions = { ...flatOptionsObject };
+  delete oldOptions[optionsMap.layoutParams.thumbnails.ratio]; // Remove new-only property that doesn't exist in old format
   ///----------- LAYOUT -------------///
   oldOptions = changeNames(
     oldOptions,

--- a/packages/lib/src/core/helpers/optionsBackwardConverter.ts
+++ b/packages/lib/src/core/helpers/optionsBackwardConverter.ts
@@ -34,6 +34,7 @@ function reverseMigrateOptions(flatOptionsObject) {
     [...reversedLayoutParams].map((ele) => [...ele].reverse())
   );
   oldOptions = process_new_to_old_ThumbnailAlignment(oldOptions);
+  oldOptions = process_new_to_old_ThumbnailRatio(oldOptions);
   oldOptions = process_new_to_old_ScrollDirection(oldOptions);
   oldOptions = process_new_to_old_LayoutOrientation(oldOptions);
   oldOptions = process_new_to_old_groupsOrder(oldOptions);
@@ -84,6 +85,12 @@ function process_new_to_old_ThumbnailAlignment(obj) {
   let _obj = obj;
   _obj = namingChange(_obj, optionsMap.layoutParams.thumbnails.alignment, 'galleryThumbnailsAlignment');
   _obj['galleryThumbnailsAlignment'] = _obj['galleryThumbnailsAlignment']?.toLowerCase();
+  return _obj;
+}
+function process_new_to_old_ThumbnailRatio(obj) {
+  // Remove the ratio property as it doesn't exist in v3
+  let _obj = obj;
+  delete _obj[optionsMap.layoutParams.thumbnails.ratio];
   return _obj;
 }
 function process_new_to_old_targetItemSizeUnit(obj) {

--- a/packages/lib/src/core/helpers/thumbnailsLogic.ts
+++ b/packages/lib/src/core/helpers/thumbnailsLogic.ts
@@ -78,27 +78,30 @@ function getThumbnailsData({
   const withInfiniteScroll = false; // this is not supported yet
   const thumbnailSize = options[optionsMap.layoutParams.thumbnails.size];
   const thumbnailRatio = options[optionsMap.layoutParams.thumbnails.ratio] || 1;
-  const thumbnailHeight = thumbnailSize / thumbnailRatio;
-  const thumbnailSizeWithSpacing = thumbnailSize + options[optionsMap.layoutParams.thumbnails.spacing];
-  const thumbnailHeightWithSpacing = thumbnailHeight + options[optionsMap.layoutParams.thumbnails.spacing];
   const horizontalThumbnails =
     thumbnailAlignment === GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM ||
     thumbnailAlignment === GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP;
+
+  // For horizontal thumbnails (top/bottom): maintain width, adjust height
+  // For vertical thumbnails (left/right): maintain height, adjust width
+  const thumbnailWidth = horizontalThumbnails ? thumbnailSize : thumbnailSize * thumbnailRatio;
+  const thumbnailHeight = horizontalThumbnails ? thumbnailSize / thumbnailRatio : thumbnailSize;
+  const thumbnailWidthWithSpacing = thumbnailWidth + options[optionsMap.layoutParams.thumbnails.spacing];
+  const thumbnailHeightWithSpacing = thumbnailHeight + options[optionsMap.layoutParams.thumbnails.spacing];
   const { width, height } = getThumbnailsContainerSize({
     horizontalThumbnails,
     containerWidth,
     containerHeight,
-    thumbnailSize,
+    thumbnailWidth,
     thumbnailHeight,
   });
   const minNumOfThumbnails = getNumberOfThumbnails({
     width,
     height,
     horizontalThumbnails,
-    thumbnailSize,
+    thumbnailWidth,
     thumbnailHeight,
   });
-
   const numberOfThumbnails = minNumOfThumbnails % 2 === 1 ? minNumOfThumbnails : minNumOfThumbnails + 1;
   const thumbnailsInEachSide = (numberOfThumbnails - 1) / 2;
 
@@ -113,7 +116,7 @@ function getThumbnailsData({
     horizontalThumbnails,
     width,
     height,
-    thumbnailSizeWithSpacing: horizontalThumbnails ? thumbnailSizeWithSpacing : thumbnailHeightWithSpacing,
+    thumbnailSizeWithSpacing: horizontalThumbnails ? thumbnailWidthWithSpacing : thumbnailHeightWithSpacing,
     activeIndex: activeIndexWithOffset,
     itemsCount: galleryItems.length,
   });
@@ -142,7 +145,7 @@ function getThumbnailsData({
           thumbnailAlignment,
           offset,
           isRTL,
-          thumbnailSizeWithSpacing: horizontalThumbnails ? thumbnailSizeWithSpacing : thumbnailHeightWithSpacing,
+          thumbnailSizeWithSpacing: horizontalThumbnails ? thumbnailWidthWithSpacing : thumbnailHeightWithSpacing,
         }),
         idx: idx,
       };
@@ -151,6 +154,8 @@ function getThumbnailsData({
     horizontalThumbnails,
     thumbnailsStyle: thumbnailsStyleWithRTLCalc,
     activeIndexOffsetMemory,
+    thumbnailWidth,
+    thumbnailHeight,
   };
 }
 
@@ -158,13 +163,13 @@ function getThumbnailsContainerSize({
   horizontalThumbnails,
   containerWidth,
   containerHeight,
-  thumbnailSize,
+  thumbnailWidth,
   thumbnailHeight,
 }: {
   horizontalThumbnails: boolean;
   containerWidth: number;
   containerHeight: number;
-  thumbnailSize: number;
+  thumbnailWidth: number;
   thumbnailHeight: number;
 }) {
   if (horizontalThumbnails) {
@@ -174,7 +179,7 @@ function getThumbnailsContainerSize({
     };
   } else {
     return {
-      width: thumbnailSize,
+      width: thumbnailWidth,
       height: containerHeight,
     };
   }
@@ -184,17 +189,17 @@ function getNumberOfThumbnails({
   width,
   height,
   horizontalThumbnails,
-  thumbnailSize,
+  thumbnailWidth,
   thumbnailHeight,
 }: {
   width: number;
   height: number;
   horizontalThumbnails: boolean;
-  thumbnailSize: number;
+  thumbnailWidth: number;
   thumbnailHeight: number;
 }) {
   if (horizontalThumbnails) {
-    return Math.ceil(width / thumbnailSize);
+    return Math.ceil(width / thumbnailWidth);
   } else {
     return Math.ceil(height / thumbnailHeight);
   }

--- a/packages/lib/src/core/helpers/thumbnailsLogic.ts
+++ b/packages/lib/src/core/helpers/thumbnailsLogic.ts
@@ -77,7 +77,10 @@ function getThumbnailsData({
 
   const withInfiniteScroll = false; // this is not supported yet
   const thumbnailSize = options[optionsMap.layoutParams.thumbnails.size];
+  const thumbnailRatio = options[optionsMap.layoutParams.thumbnails.ratio] || 1;
+  const thumbnailHeight = thumbnailSize / thumbnailRatio;
   const thumbnailSizeWithSpacing = thumbnailSize + options[optionsMap.layoutParams.thumbnails.spacing];
+  const thumbnailHeightWithSpacing = thumbnailHeight + options[optionsMap.layoutParams.thumbnails.spacing];
   const horizontalThumbnails =
     thumbnailAlignment === GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM ||
     thumbnailAlignment === GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP;
@@ -86,11 +89,14 @@ function getThumbnailsData({
     containerWidth,
     containerHeight,
     thumbnailSize,
+    thumbnailHeight,
   });
   const minNumOfThumbnails = getNumberOfThumbnails({
     width,
     height,
     horizontalThumbnails,
+    thumbnailSize,
+    thumbnailHeight,
   });
 
   const numberOfThumbnails = minNumOfThumbnails % 2 === 1 ? minNumOfThumbnails : minNumOfThumbnails + 1;
@@ -107,7 +113,7 @@ function getThumbnailsData({
     horizontalThumbnails,
     width,
     height,
-    thumbnailSizeWithSpacing,
+    thumbnailSizeWithSpacing: horizontalThumbnails ? thumbnailSizeWithSpacing : thumbnailHeightWithSpacing,
     activeIndex: activeIndexWithOffset,
     itemsCount: galleryItems.length,
   });
@@ -136,7 +142,7 @@ function getThumbnailsData({
           thumbnailAlignment,
           offset,
           isRTL,
-          thumbnailSizeWithSpacing,
+          thumbnailSizeWithSpacing: horizontalThumbnails ? thumbnailSizeWithSpacing : thumbnailHeightWithSpacing,
         }),
         idx: idx,
       };
@@ -153,16 +159,18 @@ function getThumbnailsContainerSize({
   containerWidth,
   containerHeight,
   thumbnailSize,
+  thumbnailHeight,
 }: {
   horizontalThumbnails: boolean;
   containerWidth: number;
   containerHeight: number;
   thumbnailSize: number;
+  thumbnailHeight: number;
 }) {
   if (horizontalThumbnails) {
     return {
       width: containerWidth,
-      height: thumbnailSize,
+      height: thumbnailHeight,
     };
   } else {
     return {
@@ -176,15 +184,19 @@ function getNumberOfThumbnails({
   width,
   height,
   horizontalThumbnails,
+  thumbnailSize,
+  thumbnailHeight,
 }: {
   width: number;
   height: number;
   horizontalThumbnails: boolean;
+  thumbnailSize: number;
+  thumbnailHeight: number;
 }) {
   if (horizontalThumbnails) {
-    return Math.ceil(width / height);
+    return Math.ceil(width / thumbnailSize);
   } else {
-    return Math.ceil(height / width);
+    return Math.ceil(height / thumbnailHeight);
   }
 }
 

--- a/packages/lib/src/core/helpers/thumbnailsLogic.ts
+++ b/packages/lib/src/core/helpers/thumbnailsLogic.ts
@@ -75,17 +75,15 @@ function getThumbnailsData({
     console.log('creating thumbnails for idx', activeIndex);
   }
 
-  const withInfiniteScroll = false; // this is not supported yet
+  const withInfiniteScroll = false;
   const thumbnailSize = options[optionsMap.layoutParams.thumbnails.size];
   const thumbnailRatio = options[optionsMap.layoutParams.thumbnails.ratio] || 1;
   const horizontalThumbnails =
     thumbnailAlignment === GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].BOTTOM ||
     thumbnailAlignment === GALLERY_CONSTS[optionsMap.layoutParams.thumbnails.alignment].TOP;
 
-  // For horizontal thumbnails (top/bottom): maintain width, adjust height
-  // For vertical thumbnails (left/right): maintain height, adjust width
-  const thumbnailWidth = horizontalThumbnails ? thumbnailSize : thumbnailSize * thumbnailRatio;
-  const thumbnailHeight = horizontalThumbnails ? thumbnailSize / thumbnailRatio : thumbnailSize;
+  const thumbnailWidth = horizontalThumbnails ? thumbnailSize * thumbnailRatio : thumbnailSize;
+  const thumbnailHeight = horizontalThumbnails ? thumbnailSize : thumbnailSize / thumbnailRatio;
   const thumbnailWidthWithSpacing = thumbnailWidth + options[optionsMap.layoutParams.thumbnails.spacing];
   const thumbnailHeightWithSpacing = thumbnailHeight + options[optionsMap.layoutParams.thumbnails.spacing];
   const { width, height } = getThumbnailsContainerSize({

--- a/packages/lib/src/core/helpers/thumbnailsLogic.ts
+++ b/packages/lib/src/core/helpers/thumbnailsLogic.ts
@@ -198,9 +198,8 @@ function getNumberOfThumbnails({
 }) {
   if (horizontalThumbnails) {
     return Math.ceil(width / thumbnailWidth);
-  } else {
-    return Math.ceil(height / thumbnailHeight);
   }
+  return Math.ceil(height / thumbnailHeight);
 }
 
 function getThumbnailsStyles({

--- a/packages/lib/src/settings/options/index.js
+++ b/packages/lib/src/settings/options/index.js
@@ -116,6 +116,7 @@ import layoutParams_targetItemSize_value from './layoutParams_targetItemSize_val
 import layoutParams_thumbnails_alignment from './layoutParams_thumbnails_alignment.js';
 import layoutParams_thumbnails_enable from './layoutParams_thumbnails_enable.js';
 import layoutParams_thumbnails_position from './layoutParams_thumbnails_position.js';
+import layoutParams_thumbnails_ratio from './layoutParams_thumbnails_ratio.js';
 import layoutParams_thumbnails_size from './layoutParams_thumbnails_size.js';
 import layoutParams_thumbnails_spacing from './layoutParams_thumbnails_spacing.js';
 import layoutParams_thumbnails_marginToGallery from './layoutParams_thumbnails_marginToGallery.js';
@@ -258,6 +259,7 @@ export default {
   layoutParams_thumbnails_alignment,
   layoutParams_thumbnails_enable,
   layoutParams_thumbnails_position,
+  layoutParams_thumbnails_ratio,
   layoutParams_thumbnails_size,
   layoutParams_thumbnails_spacing,
   layoutParams_thumbnails_marginToGallery,

--- a/packages/lib/src/settings/options/layoutParams_thumbnails_ratio.js
+++ b/packages/lib/src/settings/options/layoutParams_thumbnails_ratio.js
@@ -5,12 +5,16 @@ export default {
   title: 'Thumbnail Ratio',
   isRelevant: (options) => options[optionsMap.layoutParams.thumbnails.enable],
   isRelevantDescription: 'Enable thumbnails to see this option.',
-  type: INPUT_TYPES.NUMBER,
+  type: INPUT_TYPES.OPTIONS,
   default: 1,
-  min: 0.1,
-  max: 10,
-  step: 0.01,
-  description: `Set the aspect ratio (width/height) of thumbnails. A ratio of 1 creates square thumbnails (1:1). 
-  For example, a ratio of 0.75 creates 3:4 thumbnails (portrait), and 1.333 creates 4:3 thumbnails (landscape).
-  This allows thumbnails to match the main gallery aspect ratio.`,
+  get options() {
+    return [
+      { value: 16 / 9, title: '16:9' },
+      { value: 4 / 3, title: '4:3' },
+      { value: 1, title: '1:1' },
+      { value: 3 / 4, title: '3:4' },
+      { value: 9 / 16, title: '9:16' },
+    ];
+  },
+  description: `Set the aspect ratio (width/height) of thumbnails. This allows thumbnails to match the main gallery aspect ratio.`,
 };

--- a/packages/lib/src/settings/options/layoutParams_thumbnails_ratio.js
+++ b/packages/lib/src/settings/options/layoutParams_thumbnails_ratio.js
@@ -1,0 +1,16 @@
+import optionsMap from '../../core/helpers/optionsMap.js';
+import { INPUT_TYPES } from '../utils/constants.js';
+
+export default {
+  title: 'Thumbnail Ratio',
+  isRelevant: (options) => options[optionsMap.layoutParams.thumbnails.enable],
+  isRelevantDescription: 'Enable thumbnails to see this option.',
+  type: INPUT_TYPES.NUMBER,
+  default: 1,
+  min: 0.1,
+  max: 10,
+  step: 0.01,
+  description: `Set the aspect ratio (width/height) of thumbnails. A ratio of 1 creates square thumbnails (1:1). 
+  For example, a ratio of 0.75 creates 3:4 thumbnails (portrait), and 1.333 creates 4:3 thumbnails (landscape).
+  This allows thumbnails to match the main gallery aspect ratio.`,
+};

--- a/packages/lib/test/optionsConverter.spec.js
+++ b/packages/lib/test/optionsConverter.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-// import optionsMap from '../src/core/helpers/optionsMap';
+import optionsMap from '../src/core/helpers/optionsMap';
 import { flattenObject, flatToNested } from '../src/core/helpers/optionsUtils';
 import {
   migrateOptions,
@@ -19,10 +19,18 @@ describe('Styles processing', () => {
   //and the other
   it('should migrate styles from old to new ', () => {
     const migrated = migrateOptions(flattenObject(defaultOptions_old()));
+    // Add default value for new properties that don't exist in old format
+    if (typeof migrated[optionsMap.layoutParams.thumbnails.ratio] === 'undefined') {
+      migrated[optionsMap.layoutParams.thumbnails.ratio] = 1;
+    }
     expect(flatToNested(migrated)).to.eql(defaultOptions_new());
   });
   it('should have new and old styles combined coming from both old and new objects', () => {
     const migrated = addMigratedOptions(flattenObject(defaultOptions_old()));
+    // Add default value for new properties that don't exist in old format
+    if (typeof migrated[optionsMap.layoutParams.thumbnails.ratio] === 'undefined') {
+      migrated[optionsMap.layoutParams.thumbnails.ratio] = 1;
+    }
     const reversed = addOldOptions(flattenObject(defaultOptions_new()));
     delete reversed.wasConvertedToOldOptions;
     expect(migrated).to.eql(reversed);

--- a/packages/playground/src/constants/settings.js
+++ b/packages/playground/src/constants/settings.js
@@ -79,6 +79,7 @@ export const optionsBySection = {
     optionsMap.layoutParams.thumbnails.position,
     optionsMap.layoutParams.thumbnails.alignment,
     optionsMap.layoutParams.thumbnails.size,
+    optionsMap.layoutParams.thumbnails.ratio,
     optionsMap.layoutParams.thumbnails.spacing,
     optionsMap.layoutParams.thumbnails.marginToGallery,
     optionsMap.layoutParams.structure.enableStreching,


### PR DESCRIPTION
## Horizontal Thumbnails
`height: thumbnailSize, width: thumbnailSize * thumbnailRatio`
### Ratio: 4:3
<img width="751" height="538" alt="image" src="https://github.com/user-attachments/assets/33df2656-86a6-4d99-84ce-3be6ba242287" />

### Ratio: 3:4
<img width="702" height="529" alt="Screenshot 2025-11-24 at 18 45 10" src="https://github.com/user-attachments/assets/1525af4a-2c51-465c-8400-0213681f1794" />

## Vertical horizontal
`width: thumbnailSize, height: thumbnailSize * thumbnailRatio`
### Ratio: 4:3
<img width="774" height="531" alt="Screenshot 2025-11-24 at 18 46 52" src="https://github.com/user-attachments/assets/7d640ea5-f235-4f7c-b0fa-213cee62a155" />

### Ratio: 3:4
<img width="752" height="530" alt="Screenshot 2025-11-24 at 18 46 14" src="https://github.com/user-attachments/assets/1f70420b-dd65-4242-b028-4d0587169115" />


