### PR TITLE
Fix flickering gallery only ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "husky": "^9.1.7",
     "lerna": "^8.2.2",
     "lint-staged": "^15.5.1",
-    "prettier": "^3.5.3",
+    "prettier": "3.6.0",
     "prompt": "^1.3.0",
     "semver": "^7.7.2",
     "start-server-and-test": "^2.0.11"

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -92,20 +92,17 @@ export class GalleryContainer extends React.Component {
     //not sure if there needs to be a handleNEwGalleryStructure here with the intial state. currently looks like not
   }
   initializeScrollPosition() {
+    const activeIndex =
+      this.props.activeIndex !== undefined ? this.props.activeIndex : 0;
     console.log('[GalleryContainer] initializeScrollPosition', {
-      activeIndex: this.props.activeIndex,
+      activeIndex,
+      originalActiveIndex: this.props.activeIndex,
     });
-    if (this.props.activeIndex > 0) {
-      console.log(
-        '[GalleryContainer] Scrolling to active index',
-        this.props.activeIndex
-      );
-      this.scrollToItem(this.props.activeIndex, false, true, 0);
-      const currentItem = this.galleryStructure.items[this.props.activeIndex];
-      console.log(
-        '[GalleryContainer] Current item offset',
-        currentItem?.offset
-      );
+    if (activeIndex > 0) {
+      console.log('[GalleryContainer] Scrolling to active index', activeIndex);
+      this.scrollToItem(activeIndex, false, true, 0);
+      const currentItem = this.galleryStructure.items[activeIndex];
+      console.log('[GalleryContainer] Current item offset', currentItem?.offset);
       this.onGalleryScroll(currentItem.offset);
     }
   }

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -820,8 +820,7 @@ export class GalleryContainer extends React.Component {
 
   getMoreItemsIfNeeded(scrollPos) {
     if (this.deferredGettingMoreItems?.isPending) {
-      this.latestScrollPosWhileBlocked = scrollPos;
-      // Already getting more items so just remember the scroll position
+      // Already getting more items so do nothing
     } else {
       this.deferredGettingMoreItems = new Deferred();
 
@@ -864,16 +863,10 @@ export class GalleryContainer extends React.Component {
             GALLERY_CONSTS.events.NEED_MORE_ITEMS,
             this.state.items.length
           );
-
           setTimeout(() => {
             //wait a bit before allowing more items to be fetched - ugly hack before promises still not working
             this.deferredGettingMoreItems.resolve();
-            if (this.latestScrollPosWhileBlocked !== undefined) {
-              const capturedPos = this.latestScrollPosWhileBlocked;
-              this.latestScrollPosWhileBlocked = undefined; // Clear it
-              this.getMoreItemsIfNeeded(capturedPos);
-            }
-          }, 500);
+          }, 2000);
         } else {
           // No items are fetched -> reject
           this.deferredGettingMoreItems.reject();

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -27,6 +27,10 @@ import { isGalleryInViewport, Deferred } from './galleryHelpers';
 export class GalleryContainer extends React.Component {
   constructor(props) {
     super(props);
+    console.log('[GalleryContainer] constructor called', {
+      activeIndex: props.activeIndex,
+      itemsCount: props.items?.length,
+    });
     if (utils.isVerbose()) {
       console.count('[OOISSR] galleryContainer constructor', window.isMock);
     }
@@ -88,9 +92,20 @@ export class GalleryContainer extends React.Component {
     //not sure if there needs to be a handleNEwGalleryStructure here with the intial state. currently looks like not
   }
   initializeScrollPosition() {
+    console.log('[GalleryContainer] initializeScrollPosition', {
+      activeIndex: this.props.activeIndex,
+    });
     if (this.props.activeIndex > 0) {
+      console.log(
+        '[GalleryContainer] Scrolling to active index',
+        this.props.activeIndex
+      );
       this.scrollToItem(this.props.activeIndex, false, true, 0);
       const currentItem = this.galleryStructure.items[this.props.activeIndex];
+      console.log(
+        '[GalleryContainer] Current item offset',
+        currentItem?.offset
+      );
       this.onGalleryScroll(currentItem.offset);
     }
   }
@@ -133,6 +148,12 @@ export class GalleryContainer extends React.Component {
   }
 
   componentDidMount() {
+    console.log('[GalleryContainer] componentDidMount', {
+      activeIndex: this.props.activeIndex,
+      itemsCount: this.state.items?.length,
+      scrollDirection: this.state.options.scrollDirection,
+      itemClick: this.state.options.itemClick,
+    });
     const scrollHelperNewGalleryStructure = {
       galleryStructure: this.galleryStructure,
       galleryWidth: this.state.container.galleryWidth,
@@ -759,6 +780,10 @@ export class GalleryContainer extends React.Component {
   }
 
   setCurrentSlideshowViewIdx(idx) {
+    console.log('[GalleryContainer] setCurrentSlideshowViewIdx', {
+      previousIdx: this.currentSlideshowViewIdx,
+      newIdx: idx,
+    });
     this.currentSlideshowViewIdx = idx;
   }
 
@@ -776,11 +801,20 @@ export class GalleryContainer extends React.Component {
       window.dispatchEvent(this.currentHoverChangeEvent);
     }
     if (eventName === GALLERY_CONSTS.events.CURRENT_ITEM_CHANGED) {
+      console.log('[GalleryContainer] CURRENT_ITEM_CHANGED event', {
+        eventData,
+        isScrollLess: this.getIsScrollLessGallery(this.state.options),
+        firstUserInteraction: this.state.firstUserInteractionExecuted,
+      });
       this.setCurrentSlideshowViewIdx(eventData.idx);
       if (
         this.getIsScrollLessGallery(this.state.options) &&
         this.state.firstUserInteractionExecuted
       ) {
+        console.log(
+          '[GalleryContainer] Simulating horizontal scroll to item',
+          eventData.idx
+        );
         this.simulateHorizontalScrollToItem(
           this.galleryStructure.items[eventData.idx]
         );

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -102,7 +102,10 @@ export class GalleryContainer extends React.Component {
       console.log('[GalleryContainer] Scrolling to active index', activeIndex);
       this.scrollToItem(activeIndex, false, true, 0);
       const currentItem = this.galleryStructure.items[activeIndex];
-      console.log('[GalleryContainer] Current item offset', currentItem?.offset);
+      console.log(
+        '[GalleryContainer] Current item offset',
+        currentItem?.offset
+      );
       this.onGalleryScroll(currentItem.offset);
     }
   }

--- a/packages/gallery/src/components/gallery/proGallery/navigationArrows.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationArrows.js
@@ -175,7 +175,14 @@ export function ArrowButton({
   navigationArrowPortalId,
 }) {
   const isNext = (directionIsLeft && isRTL) || (!directionIsLeft && !isRTL);
-  const nextAction = () => next({ direction: directionIsLeft ? -1 : 1 });
+  const nextAction = () => {
+    console.log('[NavigationArrows] Arrow clicked', {
+      directionIsLeft,
+      isRTL,
+      isNext,
+    });
+    next({ direction: directionIsLeft ? -1 : 1 });
+  };
   const buttonProps = {
     className: arrowsBaseClasses.join(' '),
     onClick: () => setTimeout(nextAction, 0),

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -334,7 +334,8 @@ class SlideshowView extends React.Component {
         !this.props.isScrollLessGallery &&
         nextItem >= this.skipFromSlide
       ) {
-        nextItem = utils.inRange(nextItem, this.props.totalItemsCount);
+        // Wrap to the actual item index within totalItemsCount
+        nextItem = nextItem % this.props.totalItemsCount;
         console.log('[SlideshowView] Wrapped nextItem to avoid overflow', {
           wrappedNextItem: nextItem,
         });
@@ -359,6 +360,7 @@ class SlideshowView extends React.Component {
       }
       return nextItem;
     } catch (e) {
+      this.isSliding = false;
       this.onThrowScrollError('Cannot proceed to the next Item', e);
     }
   }
@@ -405,6 +407,7 @@ class SlideshowView extends React.Component {
 
       this.onScrollToItemOrGroup(nextItem, isContinuousScrolling);
     } catch (e) {
+      this.isSliding = false;
       this.onThrowScrollError('Cannot proceed to the next Group', e);
     }
   }
@@ -672,8 +675,11 @@ class SlideshowView extends React.Component {
 
     const activeIndex = this.getCenteredItemOrGroupIdxByScroll('galleryItems');
 
+    // Ensure we only react to valid indices within the actual item count
     if (
       !utils.isUndefined(activeIndex) &&
+      activeIndex >= 0 &&
+      activeIndex < this.props.totalItemsCount &&
       activeIndex !== this.state.activeIndex
     ) {
       console.log('[SlideshowView] Setting activeIndex from scroll', {
@@ -1342,9 +1348,9 @@ class SlideshowView extends React.Component {
       );
       this.props.actions.scrollToItem(this.state.activeIndex);
       this.onCurrentItemChanged();
-    } else {
-      this.setCurrentItemByScroll();
     }
+    // Don't call setCurrentItemByScroll on mount - it causes erratic jumps
+    // The scroll position is already correct at 0
     this.startAutoSlideshowIfNeeded(this.props.options);
   }
 

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -652,11 +652,9 @@ class SlideshowView extends React.Component {
       return;
     }
 
-    // Prevent scroll-based updates during autoplay or sliding
-    if (this.isSliding || this.autoSlideshowInterval) {
-      console.log(
-        '[SlideshowView] Ignoring scroll event during slide/autoplay'
-      );
+    // Only block scroll updates during programmatic sliding, not during autoplay idle time
+    if (this.isSliding) {
+      console.log('[SlideshowView] Ignoring scroll event during slide');
       return;
     }
 

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -76,6 +76,10 @@ class SlideshowView extends React.Component {
     this.skipFromSlide = Math.round(
       this.props.totalItemsCount * SKIP_SLIDES_MULTIPLIER
     ); // Used in infinite loop
+    // Initialize flags to prevent flickering during mount
+    this.isAutoScrolling = false;
+    this.isSliding = false;
+    this.isInitialMount = true;
   }
 
   isFirstItem() {
@@ -644,9 +648,16 @@ class SlideshowView extends React.Component {
       isAutoScrolling: this.isAutoScrolling,
       isSliding: this.isSliding,
       hasAutoSlideshow: !!this.autoSlideshowInterval,
+      isInitialMount: this.isInitialMount,
     });
     if (utils.isVerbose()) {
       console.log('Setting current Idx by scroll', this.isAutoScrolling);
+    }
+
+    // Block scroll reactions during initial mount to prevent flickering
+    if (this.isInitialMount) {
+      console.log('[SlideshowView] Ignoring scroll during initial mount');
+      return;
     }
 
     if (this.isAutoScrolling) {
@@ -1352,6 +1363,16 @@ class SlideshowView extends React.Component {
     // Don't call setCurrentItemByScroll on mount - it causes erratic jumps
     // The scroll position is already correct at 0
     this.startAutoSlideshowIfNeeded(this.props.options);
+
+    // Clear initial mount flag after layout stabilizes to prevent scroll events
+    // from causing index jumps during mount. Use requestAnimationFrame to wait
+    // for the next paint, then add a safety buffer for iOS scroll events
+    requestAnimationFrame(() => {
+      setTimeout(() => {
+        console.log('[SlideshowView] Clearing isInitialMount flag');
+        this.isInitialMount = false;
+      }, 150);
+    });
   }
 
   componentWillUnmount() {

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -637,6 +637,11 @@ class SlideshowView extends React.Component {
   }
 
   setCurrentItemByScroll() {
+    console.log('[SlideshowView] setCurrentItemByScroll called', {
+      isAutoScrolling: this.isAutoScrolling,
+      isSliding: this.isSliding,
+      hasAutoSlideshow: !!this.autoSlideshowInterval,
+    });
     if (utils.isVerbose()) {
       console.log('Setting current Idx by scroll', this.isAutoScrolling);
     }
@@ -644,6 +649,14 @@ class SlideshowView extends React.Component {
     if (this.isAutoScrolling) {
       //avoid this function if the scroll was originated by us (arrows or navigationPanels)
       this.isAutoScrolling = false;
+      return;
+    }
+
+    // Prevent scroll-based updates during autoplay or sliding
+    if (this.isSliding || this.autoSlideshowInterval) {
+      console.log(
+        '[SlideshowView] Ignoring scroll event during slide/autoplay'
+      );
       return;
     }
 
@@ -661,7 +674,14 @@ class SlideshowView extends React.Component {
 
     const activeIndex = this.getCenteredItemOrGroupIdxByScroll('galleryItems');
 
-    if (!utils.isUndefined(activeIndex)) {
+    if (
+      !utils.isUndefined(activeIndex) &&
+      activeIndex !== this.state.activeIndex
+    ) {
+      console.log('[SlideshowView] Setting activeIndex from scroll', {
+        previousIndex: this.state.activeIndex,
+        newIndex: activeIndex,
+      });
       utils.setStateAndLog(
         this,
         'Set Current Item',

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -328,6 +328,18 @@ class SlideshowView extends React.Component {
     console.log('[SlideshowView] nextItem calculated', { nextItem });
 
     try {
+      // Handle infinite loop wraparound BEFORE scrolling to avoid visible flicker
+      if (
+        this.props.options.groupSize === 1 &&
+        !this.props.isScrollLessGallery &&
+        nextItem >= this.skipFromSlide
+      ) {
+        nextItem = utils.inRange(nextItem, this.props.totalItemsCount);
+        console.log('[SlideshowView] Wrapped nextItem to avoid overflow', {
+          wrappedNextItem: nextItem,
+        });
+      }
+
       const itemToScroll = ignoreScrollPosition ? 0 : nextItem;
       await this.scrollToItemOrGroup(
         this.props.actions.scrollToItem,
@@ -336,16 +348,6 @@ class SlideshowView extends React.Component {
         scrollDuration,
         scrollingUpTheGallery
       );
-
-      if (
-        this.props.options.groupSize === 1 &&
-        !this.props.isScrollLessGallery
-      ) {
-        if (nextItem >= this.skipFromSlide) {
-          nextItem = utils.inRange(nextItem, this.props.totalItemsCount);
-          await this.props.actions.scrollToItem(nextItem);
-        }
-      }
 
       this.onScrollToItemOrGroup(nextItem, isContinuousScrolling);
 

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -80,6 +80,7 @@ class SlideshowView extends React.Component {
     this.isAutoScrolling = false;
     this.isSliding = false;
     this.isInitialMount = true;
+    this.mountTimeoutId = null;
   }
 
   isFirstItem() {
@@ -1368,9 +1369,10 @@ class SlideshowView extends React.Component {
     // from causing index jumps during mount. Use requestAnimationFrame to wait
     // for the next paint, then add a safety buffer for iOS scroll events
     requestAnimationFrame(() => {
-      setTimeout(() => {
+      this.mountTimeoutId = setTimeout(() => {
         console.log('[SlideshowView] Clearing isInitialMount flag');
         this.isInitialMount = false;
+        this.mountTimeoutId = null;
       }, 150);
     });
   }
@@ -1381,6 +1383,11 @@ class SlideshowView extends React.Component {
         'scroll',
         this._setCurrentItemByScroll
       );
+    }
+    // Clean up the mount timeout if component unmounts before it fires
+    if (this.mountTimeoutId) {
+      clearTimeout(this.mountTimeoutId);
+      this.mountTimeoutId = null;
     }
   }
 

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -31,6 +31,11 @@ function getDirection(code) {
 class SlideshowView extends React.Component {
   constructor(props) {
     super(props);
+    console.log('[SlideshowView] constructor', {
+      activeIndex: props.activeIndex,
+      totalItems: props.totalItemsCount,
+      isScrollLess: props.isScrollLessGallery,
+    });
     this.navigationPanelCallbackOnIndexChange = () => {};
     this.scrollToThumbnail = this.scrollToThumbnail.bind(this);
     this.clearAutoSlideshowInterval =
@@ -159,13 +164,20 @@ class SlideshowView extends React.Component {
   }
 
   async nextWithEffects(props) {
+    console.log('[SlideshowView] nextWithEffects called', props);
     const nextItem = await this.next(props);
+    console.log('[SlideshowView] nextWithEffects - nextItem result', {
+      nextItem,
+      skipFromSlide: this.skipFromSlide,
+      isScrollLess: this.props.isScrollLessGallery,
+    });
     if (
       this.props.options.groupSize === 1 &&
       this.props.isScrollLessGallery &&
       nextItem >= this.skipFromSlide
     ) {
       const skipToSlide = this.skipFromSlide - this.props.totalItemsCount;
+      console.log('[SlideshowView] Skipping to slide', skipToSlide);
 
       toggleScrollLessAnimation(() =>
         this.onScrollToItemOrGroup(skipToSlide, false)
@@ -183,7 +195,18 @@ class SlideshowView extends React.Component {
     const scrollingUpTheGallery = this.props.options.isRTL
       ? direction <= -1
       : direction >= 1;
+    console.log('[SlideshowView] next called', {
+      direction,
+      isAutoTrigger,
+      scrollDuration,
+      isKeyboardNavigation,
+      isContinuousScrolling,
+      scrollingUpTheGallery,
+      activeIndex: this.state.activeIndex,
+      isRTL: this.props.options.isRTL,
+    });
     if (this.shouldBlockNext({ scrollingUpTheGallery })) {
+      console.log('[SlideshowView] Blocking next - at gallery boundary');
       this.clearAutoSlideshowInterval();
       return;
     }
@@ -280,7 +303,18 @@ class SlideshowView extends React.Component {
     isContinuousScrolling,
     scrollingUpTheGallery,
   }) {
+    console.log('[SlideshowView] nextItem called', {
+      direction,
+      isAutoTrigger,
+      scrollDuration,
+      avoidIndividualNavigation,
+      ignoreScrollPosition,
+      isContinuousScrolling,
+      scrollingUpTheGallery,
+      currentActiveIndex: this.state.activeIndex,
+    });
     if (this.isSliding) {
+      console.log('[SlideshowView] Already sliding, returning');
       return;
     }
 
@@ -291,6 +325,7 @@ class SlideshowView extends React.Component {
       avoidIndividualNavigation,
       isAutoTrigger
     );
+    console.log('[SlideshowView] nextItem calculated', { nextItem });
 
     try {
       const itemToScroll = ignoreScrollPosition ? 0 : nextItem;
@@ -332,11 +367,20 @@ class SlideshowView extends React.Component {
     isContinuousScrolling = false,
     scrollingUpTheGallery,
   }) {
+    console.log('[SlideshowView] nextGroup called', {
+      direction,
+      scrollDuration,
+      isContinuousScrolling,
+      scrollingUpTheGallery,
+      currentActiveIndex: this.state.activeIndex,
+    });
     if (this.isSliding) {
+      console.log('[SlideshowView] Already sliding in nextGroup, returning');
       return;
     }
 
     const nextGroup = this.getNextItemOrGroupToScrollTo('nextGroup', direction);
+    console.log('[SlideshowView] nextGroup calculated', { nextGroup });
 
     try {
       await this.scrollToItemOrGroup(
@@ -392,6 +436,11 @@ class SlideshowView extends React.Component {
   }
 
   onScrollToItemOrGroup(nextItem, isContinuousScrolling) {
+    console.log('[SlideshowView] onScrollToItemOrGroup', {
+      previousActiveIndex: this.state.activeIndex,
+      nextItem,
+      isContinuousScrolling,
+    });
     utils.setStateAndLog(
       this,
       'Next Item',
@@ -1250,9 +1299,16 @@ class SlideshowView extends React.Component {
   }
 
   componentDidMount() {
+    console.log('[SlideshowView] componentDidMount', {
+      activeIndex: this.state.activeIndex,
+      totalItems: this.props.totalItemsCount,
+      id: this.props.id,
+      isScrollLess: this.props.isScrollLessGallery,
+    });
     this.scrollElement = window.document.querySelector(
       `#pro-gallery-${this.props.id} #gallery-horizontal-scroll-${this.props.id}`
     );
+    console.log('[SlideshowView] scrollElement found:', !!this.scrollElement);
     if (this.scrollElement) {
       this.scrollElement.addEventListener(
         'scroll',
@@ -1260,6 +1316,10 @@ class SlideshowView extends React.Component {
       );
     }
     if (this.state.activeIndex > 0) {
+      console.log(
+        '[SlideshowView] Scrolling to initial activeIndex',
+        this.state.activeIndex
+      );
       this.props.actions.scrollToItem(this.state.activeIndex);
       this.onCurrentItemChanged();
     } else {
@@ -1280,6 +1340,12 @@ class SlideshowView extends React.Component {
   //-----------------------------------------| RENDER |--------------------------------------------//
 
   render() {
+    console.log('[SlideshowView] render', {
+      activeIndex: this.state.activeIndex,
+      hideLeftArrow: this.state.hideLeftArrow,
+      hideRightArrow: this.state.hideRightArrow,
+      isInView: this.state.isInView,
+    });
     if (utils.isVerbose()) {
       console.count('galleryView render');
       console.count('Rendering Gallery count');

--- a/packages/gallery/src/components/helpers/scrollHelper.js
+++ b/packages/gallery/src/components/helpers/scrollHelper.js
@@ -3,6 +3,12 @@ import { GALLERY_CONSTS } from 'pro-gallery-lib';
 import { Deferred } from '../gallery/proGallery/galleryHelpers';
 
 export function scrollToItemImp(scrollParams) {
+  console.log('[scrollHelper] scrollToItemImp called', {
+    itemIdx: scrollParams.itemIdx,
+    scrollDirection: scrollParams.scrollDirection,
+    fixedScroll: scrollParams.fixedScroll,
+    isContinuousScrolling: scrollParams.isContinuousScrolling,
+  });
   let to, from;
   const {
     scrollMarginCorrection = 0,
@@ -46,6 +52,12 @@ export function scrollToItemImp(scrollParams) {
         ? utils.get(item, 'offset.left')
         : utils.get(item, 'offset.top');
 
+    console.log('[scrollHelper] Found item to scroll to', {
+      itemIdx,
+      item,
+      to,
+      scrollDirection,
+    });
     if (utils.isVerbose()) {
       console.log('Scrolling to position ' + to, item);
     }
@@ -63,6 +75,14 @@ export function scrollToItemImp(scrollParams) {
       to = Math.min(to, totalWidth - galleryWidth + scrollMarginCorrection);
       to *= rtlFix;
       from *= rtlFix;
+      console.log('[scrollHelper] Horizontal scroll calculated', {
+        from,
+        to,
+        galleryWidth,
+        totalWidth,
+        rtlFix,
+        isRTL,
+      });
       if (utils.isVerbose()) {
         console.log('Scrolling to new position ' + to, this);
       }

--- a/packages/gallery/src/components/hoc/withMagnified.js
+++ b/packages/gallery/src/components/hoc/withMagnified.js
@@ -51,16 +51,37 @@ function withMagnified(WrappedComponent) {
     onMouseDown(e) {
       const { clientX, clientY } = e;
       const { x, y, shouldMagnify } = this.state;
+      console.log('[withMagnified] onMouseDown', {
+        clientX,
+        clientY,
+        x,
+        y,
+        shouldMagnify,
+      });
       if (!shouldMagnify) {
-        this.setState(this.getMagnifyInitialPos(e));
+        const initialPos = this.getMagnifyInitialPos(e);
+        console.log(
+          '[withMagnified] Setting magnify initial position',
+          initialPos
+        );
+        this.setState(initialPos);
       } else {
         this.dragStartX = x + clientX;
         this.dragStartY = y + clientY;
         this.dragStarted = true;
+        console.log('[withMagnified] Starting drag', {
+          dragStartX: this.dragStartX,
+          dragStartY: this.dragStartY,
+        });
       }
     }
     onMouseUp() {
+      console.log('[withMagnified] onMouseUp', {
+        isDragging: this.isDragging,
+        dragStarted: this.dragStarted,
+      });
       if (!this.isDragging) {
+        console.log('[withMagnified] Toggling magnify');
         this.toggleMagnify();
       }
       this.dragStarted = false;
@@ -69,6 +90,12 @@ function withMagnified(WrappedComponent) {
 
     toggleMagnify(bool) {
       const { shouldMagnify } = this.state;
+      const newValue = typeof bool === 'boolean' ? bool : !shouldMagnify;
+      console.log('[withMagnified] toggleMagnify', {
+        currentShouldMagnify: shouldMagnify,
+        newValue,
+        bool,
+      });
       if (typeof bool === 'boolean') {
         this.setState({ shouldMagnify: bool });
       } else {
@@ -82,10 +109,17 @@ function withMagnified(WrappedComponent) {
         options: { behaviourParams },
       } = this.props;
       const { magnificationValue } = behaviourParams.item.content;
-      return {
+      const dimensions = {
         magnifiedHeight: innerHeight * magnificationValue,
         magnifiedWidth: innerWidth * magnificationValue,
       };
+      console.log('[withMagnified] getMagnifiedDimensions', {
+        innerHeight,
+        innerWidth,
+        magnificationValue,
+        dimensions,
+      });
+      return dimensions;
     }
     getPreloadImage() {
       const { createUrl, id, style, imageDimensions, options } = this.props;
@@ -152,8 +186,17 @@ function withMagnified(WrappedComponent) {
     isMagnifiedBiggerThanContainer(itemStyle) {
       const { magnifiedWidth, magnifiedHeight } = this.getMagnifiedDimensions();
       const { cubedWidth, cubedHeight } = itemStyle;
+      const isBigger =
+        cubedWidth < magnifiedWidth || cubedHeight < magnifiedHeight;
+      console.log('[withMagnified] isMagnifiedBiggerThanContainer', {
+        magnifiedWidth,
+        magnifiedHeight,
+        cubedWidth,
+        cubedHeight,
+        isBigger,
+      });
 
-      return cubedWidth < magnifiedWidth || cubedHeight < magnifiedHeight;
+      return isBigger;
     }
 
     getMagnifyInitialPos(e) {
@@ -222,6 +265,11 @@ function withMagnified(WrappedComponent) {
     render() {
       const { shouldMagnify } = this.state;
       const { itemClick } = this.props.options;
+      console.log('[withMagnified] render', {
+        shouldMagnify,
+        itemClick,
+        isMagnifyMode: itemClick === GALLERY_CONSTS.itemClick.MAGNIFY,
+      });
       if (itemClick !== GALLERY_CONSTS.itemClick.MAGNIFY) {
         return <WrappedComponent {...this.props} />;
       }

--- a/packages/gallery/src/components/hoc/withMagnified.js
+++ b/packages/gallery/src/components/hoc/withMagnified.js
@@ -51,37 +51,17 @@ function withMagnified(WrappedComponent) {
     onMouseDown(e) {
       const { clientX, clientY } = e;
       const { x, y, shouldMagnify } = this.state;
-      console.log('[withMagnified] onMouseDown', {
-        clientX,
-        clientY,
-        x,
-        y,
-        shouldMagnify,
-      });
       if (!shouldMagnify) {
         const initialPos = this.getMagnifyInitialPos(e);
-        console.log(
-          '[withMagnified] Setting magnify initial position',
-          initialPos
-        );
         this.setState(initialPos);
       } else {
         this.dragStartX = x + clientX;
         this.dragStartY = y + clientY;
         this.dragStarted = true;
-        console.log('[withMagnified] Starting drag', {
-          dragStartX: this.dragStartX,
-          dragStartY: this.dragStartY,
-        });
       }
     }
     onMouseUp() {
-      console.log('[withMagnified] onMouseUp', {
-        isDragging: this.isDragging,
-        dragStarted: this.dragStarted,
-      });
       if (!this.isDragging) {
-        console.log('[withMagnified] Toggling magnify');
         this.toggleMagnify();
       }
       this.dragStarted = false;
@@ -90,12 +70,6 @@ function withMagnified(WrappedComponent) {
 
     toggleMagnify(bool) {
       const { shouldMagnify } = this.state;
-      const newValue = typeof bool === 'boolean' ? bool : !shouldMagnify;
-      console.log('[withMagnified] toggleMagnify', {
-        currentShouldMagnify: shouldMagnify,
-        newValue,
-        bool,
-      });
       if (typeof bool === 'boolean') {
         this.setState({ shouldMagnify: bool });
       } else {
@@ -109,17 +83,10 @@ function withMagnified(WrappedComponent) {
         options: { behaviourParams },
       } = this.props;
       const { magnificationValue } = behaviourParams.item.content;
-      const dimensions = {
+      return {
         magnifiedHeight: innerHeight * magnificationValue,
         magnifiedWidth: innerWidth * magnificationValue,
       };
-      console.log('[withMagnified] getMagnifiedDimensions', {
-        innerHeight,
-        innerWidth,
-        magnificationValue,
-        dimensions,
-      });
-      return dimensions;
     }
     getPreloadImage() {
       const { createUrl, id, style, imageDimensions, options } = this.props;
@@ -186,17 +153,8 @@ function withMagnified(WrappedComponent) {
     isMagnifiedBiggerThanContainer(itemStyle) {
       const { magnifiedWidth, magnifiedHeight } = this.getMagnifiedDimensions();
       const { cubedWidth, cubedHeight } = itemStyle;
-      const isBigger =
-        cubedWidth < magnifiedWidth || cubedHeight < magnifiedHeight;
-      console.log('[withMagnified] isMagnifiedBiggerThanContainer', {
-        magnifiedWidth,
-        magnifiedHeight,
-        cubedWidth,
-        cubedHeight,
-        isBigger,
-      });
 
-      return isBigger;
+      return cubedWidth < magnifiedWidth || cubedHeight < magnifiedHeight;
     }
 
     getMagnifyInitialPos(e) {
@@ -265,11 +223,6 @@ function withMagnified(WrappedComponent) {
     render() {
       const { shouldMagnify } = this.state;
       const { itemClick } = this.props.options;
-      console.log('[withMagnified] render', {
-        shouldMagnify,
-        itemClick,
-        isMagnifyMode: itemClick === GALLERY_CONSTS.itemClick.MAGNIFY,
-      });
       if (itemClick !== GALLERY_CONSTS.itemClick.MAGNIFY) {
         return <WrappedComponent {...this.props} />;
       }

--- a/packages/gallery/src/components/item/imageRenderer.js
+++ b/packages/gallery/src/components/item/imageRenderer.js
@@ -6,6 +6,11 @@ class ImageRenderer extends React.Component {
     this.imageRef = null;
   }
   componentDidMount() {
+    console.log('[ImageRenderer] componentDidMount', {
+      id: this.props.id,
+      hasOnLoad: typeof this.props.onLoad === 'function',
+      imageComplete: this.imageRef?.complete,
+    });
     if (this.imageRef?.complete && typeof this.props.onLoad === 'function') {
       this.props.onLoad();
     }

--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -28,6 +28,11 @@ const TextWithSecondMedia = withSecondaryMedia(TextItem);
 class ItemView extends React.Component {
   constructor(props) {
     super(props);
+    console.log('[ItemView] constructor', {
+      id: props.id,
+      idx: props.idx,
+      itemClick: props.options?.itemClick,
+    });
     this.props.actions.eventsListener(
       GALLERY_CONSTS.events.ITEM_CREATED,
       this.props
@@ -95,6 +100,11 @@ class ItemView extends React.Component {
   }
 
   onMouseEnter() {
+    console.log('[ItemView] onMouseEnter', {
+      itemId: this.props.id,
+      idx: this.props.idx,
+      isMobile: utils.isMobile(),
+    });
     if (!utils.isMobile()) {
       this.props.actions.eventsListener(
         GALLERY_CONSTS.events.HOVER_SET,
@@ -194,6 +204,11 @@ class ItemView extends React.Component {
   }
 
   onItemWrapperClick(e) {
+    console.log('[ItemView] onItemWrapperClick', {
+      itemId: this.props.id,
+      idx: this.props.idx,
+      targetTag: e.target?.tagName,
+    });
     const clickTarget = 'item-media';
     this.onItemClick(e, clickTarget);
   }
@@ -205,6 +220,13 @@ class ItemView extends React.Component {
   }
 
   onItemClick(e, clickTarget, shouldPreventDefault = true) {
+    console.log('[ItemView] onItemClick', {
+      clickTarget,
+      shouldPreventDefault,
+      itemId: this.props.id,
+      idx: this.props.idx,
+      itemClick: this.props.options?.itemClick,
+    });
     if (
       utils.isFunction(utils.get(window, 'galleryWixCodeApi.onItemClicked'))
     ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18108,21 +18108,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:3.6.0":
+  version: 3.6.0
+  resolution: "prettier@npm:3.6.0"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/636897c8084b71ef1f740a46199df0d8f6ed896aa497212cc8cc229d3026b9dca82fa92f61e55924c4708cea11e39a88478e2d93c4818741c55b7408a9ac6d91
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^2.1.2":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:
     prettier: bin-prettier.js
   checksum: 10c0/463ea8f9a0946cd5b828d8cf27bd8b567345cf02f56562d5ecde198b91f47a76b7ac9eae0facd247ace70e927143af6135e8cf411986b8cb8478784a4d6d724a
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.5.3":
-  version: 3.7.4
-  resolution: "prettier@npm:3.7.4"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10c0/9675d2cd08eacb1faf1d1a2dbfe24bfab6a912b059fc9defdb380a408893d88213e794a40a2700bd29b140eb3172e0b07c852853f6e22f16f3374659a1a13389
   languageName: node
   linkType: hard
 
@@ -18230,7 +18230,7 @@ __metadata:
     husky: "npm:^9.1.7"
     lerna: "npm:^8.2.2"
     lint-staged: "npm:^15.5.1"
-    prettier: "npm:^3.5.3"
+    prettier: "npm:3.6.0"
     prompt: "npm:^1.3.0"
     semver: "npm:^7.7.2"
     start-server-and-test: "npm:^2.0.11"


### PR DESCRIPTION
Reverted this PR: https://github.com/wix-incubator/pro-gallery/pull/1465/changes
The flickers are not infinite now - once you scroll down the image resets to the first and it flickers one time, then the next image flickers one time, and then it continues play regulary.
Demo: https://wix.slack.com/files/U08LJ0KRZ60/F0A997A5H19/screenrecording_01-18-2026_19-19-55_1.mov